### PR TITLE
Updates for 0.22.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "thefuzz" %}
-{% set version = "0.19.0" %}
+{% set version = "0.22.1" %}
 
 
 package:
@@ -8,13 +8,11 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/thefuzz-{{ version }}.tar.gz
-  sha256: 6f7126db2f2c8a54212b05e3a740e45f4291c497d75d20751728f635bb74aa3d
+  sha256: 7138039a7ecf540da323792d8592ef9902b1d79eb78c147d4f20664de79f3680
 
 build:
   number: 0
-  # Currently python-levenshtein isn't available on s390x
-  skip: True  # [s390x]
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
@@ -24,16 +22,13 @@ requirements:
     - wheel
   run:
     - python
-    # Optional, provides a 4-10x speedup in String Matching:
-    - python-levenshtein >=0.12
+    - rapidfuzz >=3.0.0,<4.0.0a
 
 test:
   imports:
     - thefuzz
-    - thefuzz.StringMatcher
     - thefuzz.fuzz
     - thefuzz.process
-    - thefuzz.string_processing
     - thefuzz.utils
   requires:
     - pip
@@ -42,11 +37,11 @@ test:
 
 about:
   home: https://github.com/seatgeek/thefuzz
-  license: GPL-2.0-or-later
-  license_family: GPL
+  license: MIT
+  license_family: MIT
   license_file: LICENSE.txt
   description: |
-    Fuzzy string matching like a boss. It uses [Levenshtein Distance][_LD] to 
+    Fuzzy string matching like a boss. It uses [Levenshtein Distance][_LD] to
     calculate the differences between sequences in a simple-to-use package.
 
     [_LD]: https://en.wikipedia.org/wiki/Levenshtein_distance

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,6 +40,7 @@ about:
   license: MIT
   license_family: MIT
   license_file: LICENSE.txt
+  summary: Fuzzy string matching library.
   description: |
     Fuzzy string matching like a boss. It uses [Levenshtein Distance][_LD] to
     calculate the differences between sequences in a simple-to-use package.


### PR DESCRIPTION
thefuzz 0.22.1

**Destination channel:** main

### Links

- [{PKG-4860}](//anaconda.atlassian.net/browse/PKG-4860) 
- [Upstream repository](https://github.com/seatgeek/thefuzz)
- [Upstream changelog/diff](https://github.com/seatgeek/thefuzz/compare/0.19.0..0.22.1)

### Explanation of changes:

- Update hash and version
- Added standard install line
- Changed dependencies as per version
- Changed license as per upstream change
